### PR TITLE
Reverant implement

### DIFF
--- a/contracts/src/components.cairo
+++ b/contracts/src/components.cairo
@@ -1,3 +1,5 @@
+mod revenant;
+
 #[derive(Component, Copy, Drop, Serde)]
 struct Position {
     #[key]
@@ -73,7 +75,17 @@ struct Game {
     game_id: u32, // increment
     start_time: u64,
     prize: u32,
-    status: bool 
+    status: bool
+}
+
+#[derive(Component, Copy, Drop, Serde, SerdeLen)]
+struct OutpostCount {
+    #[key]
+    game_id: u32,
+    #[key]
+    address: felt252,
+    count: u32,
+    name: felt252
 }
 
 // Config Components ---------------------------------------------------------------------

--- a/contracts/src/components/revenant.cairo
+++ b/contracts/src/components/revenant.cairo
@@ -1,0 +1,25 @@
+use starknet::ContractAddress;
+
+#[derive(Component, Copy, Drop, Serde, SerdeLen)]
+struct Revenant {
+    #[key]
+    game_id: u32,
+    #[key]
+    address: ContractAddress,
+    name: felt252,
+    outpost_count: u32,
+    status: u32
+}
+
+mod RevenantStatus {
+    const not_start: u32 = 0;
+    const started: u32 = 1;
+// TODO: More status, like outpost has reach limit / has been beated / etc...
+}
+
+#[generate_trait]
+impl RevenantImpl of RevenantTrait {
+    fn assert_started(self: Revenant) {
+        assert(self.status == RevenantStatus::started, 'Revenant has not been created');
+    }
+}

--- a/contracts/src/systems.cairo
+++ b/contracts/src/systems.cairo
@@ -1,4 +1,5 @@
 mod create_outpost;
+mod create_revenant;
 // mod TradeOutpost;
 mod destroy_outpost;
 mod reinforce_outpost;

--- a/contracts/src/systems/create_outpost.cairo
+++ b/contracts/src/systems/create_outpost.cairo
@@ -12,6 +12,9 @@ mod create_outpost {
     use RealmsRisingRevenant::components::Prosperity;
     use RealmsRisingRevenant::components::Game;
     use RealmsRisingRevenant::components::Ownership;
+    use RealmsRisingRevenant::components::revenant::{
+        Revenant, RevenantStatus, RevenantImpl, RevenantTrait
+    };
     use RealmsRisingRevenant::utils::random::{Random, RandomImpl};
 
     use RealmsRisingRevenant::components::GameEntityCounter;
@@ -28,6 +31,10 @@ mod create_outpost {
 
         assert(game.status, 'game is not running');
         // check if the game has started
+
+        let mut revenant = get!(ctx.world, (game_id, ctx.origin), Revenant);
+        revenant.assert_started();
+        // TODO: Check revenant's outpost count reach the limit.
 
         gameData.outpost_count += 1;
 
@@ -61,6 +68,9 @@ mod create_outpost {
             ctx.world,
             (lifes, defence, name, prosperity, position, ownership, gameData)
         );
+
+        revenant.outpost_count = revenant.outpost_count + 1;
+        set!(ctx.world, (revenant));
 
         entity_id
     }

--- a/contracts/src/systems/create_outpost.cairo
+++ b/contracts/src/systems/create_outpost.cairo
@@ -12,6 +12,7 @@ mod create_outpost {
     use RealmsRisingRevenant::components::Prosperity;
     use RealmsRisingRevenant::components::Game;
     use RealmsRisingRevenant::components::Ownership;
+    use RealmsRisingRevenant::utils::random::{Random, RandomImpl};
 
     use RealmsRisingRevenant::components::GameEntityCounter;
 
@@ -47,9 +48,11 @@ mod create_outpost {
         let mut prosperity = Prosperity { entity_id, game_id, value: 1000 };
 
         // // // We set the position of the outpost
-        // // // TODO: Get random coordinates
-        // let (x, y) = getRandomCoordinates(ctx);
-        let mut position = Position { entity_id, game_id, x: 1, y: 1 };
+        let seed = starknet::get_tx_info().unbox().transaction_hash;
+        let mut random = RandomImpl::new(seed);
+        let x = random.next_u32(0, 100);
+        let y = random.next_u32(0, 100);
+        let mut position = Position { entity_id, game_id, x, y };
 
         // We set the ownership of theoutpostto the player who created it
         let mut ownership = Ownership { entity_id, game_id, address: ctx.origin.into() };
@@ -61,10 +64,6 @@ mod create_outpost {
 
         entity_id
     }
-// fn getRandomCoordinates(ctx: Context) -> (u32, u32) {
-//     // TODO: get random coordinates
-//     (1, 1)
-// }
 }
 
 

--- a/contracts/src/systems/create_revenant.cairo
+++ b/contracts/src/systems/create_revenant.cairo
@@ -1,0 +1,35 @@
+#[system]
+mod create_revenant {
+    use array::ArrayTrait;
+    use box::BoxTrait;
+    use traits::Into;
+    use dojo::world::Context;
+
+    use RealmsRisingRevenant::components::Game;
+    use RealmsRisingRevenant::components::revenant::{Revenant, RevenantStatus};
+
+    // this will create a revenant with name
+    fn execute(ctx: Context, game_id: u32, name: felt252) -> u128 {
+        assert(name != 0, 'name length must larger than 0');
+
+        let game = get!(ctx.world, game_id, Game);
+        assert(game.status, 'game is not running');
+
+        let existed_revenant = get!(ctx.world, (game_id, ctx.origin), (Revenant));
+        assert(
+            existed_revenant.status == RevenantStatus::not_start, 'Revenant has already created'
+        );
+
+        let revenant = Revenant {
+            game_id,
+            address: ctx.origin,
+            name: name,
+            outpost_count: 0,
+            status: RevenantStatus::started
+        };
+        set!(ctx.world, (revenant));
+
+        // TODO: What should return after create revenant successfully 
+        0
+    }
+}

--- a/contracts/src/systems/destroy_outpost.cairo
+++ b/contracts/src/systems/destroy_outpost.cairo
@@ -43,6 +43,8 @@ mod destroy_outpost{
         defence.plague -= 1;
         let _ = set!(ctx.world, (lifes, defence));
 
+        // TODO: Should we reduce outpost_count of revenant after outpost has been destroy?
+
         // Emit World Event
         return ();
     }


### PR DESCRIPTION
- implement the outpost random position
- implement the revenant component

Players must create revenant, then create outpost.
Client able to get the outpost account from the revenant's component. 